### PR TITLE
Superusers can now add (other) superusers as applicants.

### DIFF
--- a/proposals/forms.py
+++ b/proposals/forms.py
@@ -54,7 +54,10 @@ class ProposalForm(UserKwargModelFormMixin, ConditionalModelForm):
         super(ProposalForm, self).__init__(*args, **kwargs)
         self.fields['relation'].empty_label = None
 
-        applicants = get_user_model().objects.exclude(is_superuser=True)
+        applicants = get_user_model().objects.all()
+
+        if not self.user.is_superuser:
+            applicants = applicants.exclude(is_superuser=True)
 
         supervisors = applicants.exclude(pk=self.user.pk)
 


### PR DESCRIPTION
This fixes a bug while testing with a superuser account which causes
the applicant box to be empty, which is an illegal state